### PR TITLE
refactor!: added useLocalProjects parameter; updated CONTRIBUTING.md; moved useMavenLocal to root project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,29 @@ Bug reports and pull requests from users are what keep this project working.
 5. Publish the branch (`git push origin my-new-feature`)
 6. Create a new Pull Request
 
-## Running for development
+## Development
 
-For running the plugin in development locally, there are primarily three things to be achieved compared to standard development scenario:
+For using the plugins for development locally, there are two approaches:
 
-- `repositories` need to include `mavenLocal()`
-- publishing needs to happen to maven local
-- signing needs to be disabled for publishing
+1. Using Maven Local
+   This scenario includes primarily three things to be achieved compared to standard development scenario:
 
-To achieve that, this plugin has been preconfigured with conditional configuration that can be enabled as follows:
+   - `repositories` need to include `mavenLocal()`
+   - publishing needs to happen to maven local
+   - signing needs to be disabled for publishing
 
-1. Via `local.properties` (applies both to Android Studio and `gradlew`): add `useMavenLocal=true`
+   This project has been preconfigured with such conditional configuration that can be enabled as follows:
 
-2. Via a CLI flag: `./gradlew -P useMavenLocal=true ...`
+   - Via root project's `local.properties` (applies both to Android Studio and `gradlew`): add `useMavenLocal=true`
+   - Via a CLI flag: `./gradlew -PuseMavenLocal=true ...`
+
+2. Using local modules in the project
+   This scenario utilizes the local modules (subprojects) residing inside `packages/` to be used in place of dependencies so that between modifying the code in a plugin and running it in the sample app there is no need to publish to Maven.
+
+   This project has been preconfigured with such conditional configuration that can be enabled as follows:
+
+   - Via root project's `local.properties` (applies both to Android Studio and `gradlew`): add `useLocalProjects=true`
+   - Via a CLI flag: `./gradlew -PuseLocalProjects=true ...`
 
 ## Publishing
 

--- a/apps/auth-sample/build.gradle.kts
+++ b/apps/auth-sample/build.gradle.kts
@@ -2,6 +2,8 @@
 
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
+val useLocalProjects = project.rootProject.extra["useLocalProjects"] as Boolean
+
 plugins {
     `android-application`
     id("kotlin-kapt")
@@ -17,14 +19,16 @@ var googleGmsPath = "com.openmobilehub.android.auth.plugin.google.gms.OmhAuthFac
 var googleNongmsPath = "com.openmobilehub.android.auth.plugin.google.nongms.presentation.OmhAuthFactoryImpl"
 
 omhConfig {
+    enableLocalProjects = useLocalProjects
+
     bundle("singleBuild") {
         auth {
             gmsService {
-                dependency = googleGmsDependency
+                if(!useLocalProjects) dependency = googleGmsDependency
                 path = googleGmsPath
             }
             nonGmsService {
-                dependency = googleNongmsDependency
+                if(!useLocalProjects) dependency = googleNongmsDependency
                 path = googleNongmsPath
             }
         }
@@ -32,7 +36,7 @@ omhConfig {
     bundle("gms") {
         auth {
             gmsService {
-                dependency = googleGmsDependency
+                if(!useLocalProjects) dependency = googleGmsDependency
                 path = googleGmsPath
             }
         }
@@ -40,7 +44,7 @@ omhConfig {
     bundle("nongms") {
         auth {
             nonGmsService {
-                dependency = googleNongmsDependency
+                if(!useLocalProjects) dependency = googleNongmsDependency
                 path = googleNongmsPath
             }
         }
@@ -121,6 +125,13 @@ dependencies {
     testImplementation(Libs.junit)
     androidTestImplementation(Libs.androidJunit)
     androidTestImplementation(Libs.esspreso)
+
+    // Use local implementation instead of dependencies
+    if(useLocalProjects) {
+        implementation(project(":packages:core"))
+        implementation(project(":packages:plugin-google-gms"))
+        implementation(project(":packages:plugin-google-non-gms"))
+    }
 }
 
 fun getValueFromEnvOrProperties(name: String): Any? {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,24 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
-import org.jetbrains.kotlin.konan.properties.hasProperty
 import java.util.Properties
 
-var properties = Properties()
-properties.load(project.rootProject.file("local.properties").inputStream())
-var useMavenLocal = (rootProject.ext.has("useMavenLocal") && rootProject.ext.get("useMavenLocal") == "true") || (properties.hasProperty("useMavenLocal") && properties.getProperty("useMavenLocal") == "true")
+val properties = Properties()
+val localPropertiesFile = project.file("local.properties")
+if(localPropertiesFile.exists()) {
+    properties.load(localPropertiesFile.inputStream())
+}
+val useMavenLocal = getBooleanFromProperties("useMavenLocal")
+val useLocalProjects = getBooleanFromProperties("useLocalProjects")
+
+if(useLocalProjects) {
+    println("OMH Auth project running with useLocalProjects enabled ")
+}
+
+if(useMavenLocal) {
+    println("OMH Auth project running with useMavenLocal enabled${if(useLocalProjects) ", but only publishing will be altered since dependencies are overriden by useLocalProjects" else ""} ")
+}
+
+project.extra.set("useLocalProjects", useLocalProjects)
+project.extra.set("useMavenLocal", useMavenLocal)
 
 plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
@@ -70,4 +84,9 @@ nexusPublishing {
 fun getValueFromEnvOrProperties(name: String): Any? {
     val localProperties = gradleLocalProperties(rootDir)
     return System.getenv(name) ?: localProperties[name]
+}
+
+fun getBooleanFromProperties(name: String): Boolean {
+    val localProperties = gradleLocalProperties(rootDir)
+    return (project.ext.has(name) && project.ext.get(name) == "true") || localProperties[name] == "true"
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,12 +1,24 @@
+import org.jetbrains.kotlin.konan.properties.hasProperty
+import java.util.Properties
+
+var properties = Properties()
+var localPropertiesFile = project.file("../local.properties")
+if(localPropertiesFile.exists()) {
+    properties.load(localPropertiesFile.inputStream())
+}
+var useMavenLocal = (rootProject.ext.has("useMavenLocal") && rootProject.ext.get("useMavenLocal") == "true") || (properties.hasProperty("useMavenLocal") && properties.getProperty("useMavenLocal") == "true")
+
 plugins {
     `kotlin-dsl`
 }
 
 repositories {
+    if(useMavenLocal) {
+        mavenLocal()
+    }
     mavenCentral()
     google()
     gradlePluginPortal()
-    mavenLocal()
     maven("https://s01.oss.sonatype.org/content/groups/staging/")
 }
 
@@ -16,6 +28,9 @@ configurations.all {
             "javapoet" -> useVersion("1.13.0")
         }
     }
+    resolutionStrategy {
+        cacheChangingModulesFor(0, TimeUnit.SECONDS)
+    }
 }
 
 dependencies {
@@ -24,6 +39,8 @@ dependencies {
     implementation("com.android.tools.build:gradle:7.4.1")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0")
     implementation("org.jacoco:org.jacoco.core:0.8.8")
-    implementation("com.openmobilehub.android:omh-core:1.0.2-beta")
     implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:1.8.10")
+    implementation("com.openmobilehub.android:omh-core:2.0.0-beta") {
+        isChanging = true
+    }
 }

--- a/buildSrc/src/main/kotlin/android-base-lib.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-base-lib.gradle.kts
@@ -15,16 +15,8 @@
  */
 
 import org.gradle.plugins.signing.SigningPlugin
-import org.jetbrains.kotlin.konan.properties.hasProperty
-import java.util.Properties
 
-var properties = Properties()
-properties.load(project.rootProject.file("local.properties").inputStream())
-var useMavenLocal = (rootProject.ext.has("useMavenLocal") && rootProject.ext.get("useMavenLocal") == "true") || (properties.hasProperty("useMavenLocal") && properties.getProperty("useMavenLocal") == "true")
-
-if(useMavenLocal) {
-    println(" == OMH Auth project running in local development mode, using maven local  == ")
-}
+val useMavenLocal = project.rootProject.extra["useMavenLocal"] as Boolean
 
 plugins {
     id("com.android.library")

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,9 +28,14 @@ minimunCoverageAllowed=0.8
 # Libraries configuration
 group=com.openmobilehub.android.auth
 
-# Local development mode setting
+# Maven Local mode setting
 # when set to true here or in local.properties:
 # - Maven publishing will publish to mavenLocal
 # - repositories will be configured with mavenLocal() as well
 # - signing will be disabled for publishing
 useMavenLocal=false
+
+# Local projects usage in place of dependencies setting
+# when set to true here or in local.properties, local projects
+# added in build.gradle.kts will be supported in place of map plugin dependencies
+useLocalProjects=false

--- a/packages/plugin-google-gms/build.gradle.kts
+++ b/packages/plugin-google-gms/build.gradle.kts
@@ -8,8 +8,14 @@ android {
     namespace = "com.openmobilehub.android.auth.plugin.google.gms"
 }
 
+val useLocalProjects = project.rootProject.extra["useLocalProjects"] as Boolean
+
 dependencies {
-    api("com.openmobilehub.android.auth:core:2.0.0-beta")
+    if(useLocalProjects) {
+        api(project(":packages:core"))
+    } else {
+        api("com.openmobilehub.android.auth:core:2.0.0-beta")
+    }
 
     // KTX
     implementation(Libs.coreKtx)

--- a/packages/plugin-google-non-gms/build.gradle.kts
+++ b/packages/plugin-google-non-gms/build.gradle.kts
@@ -24,8 +24,14 @@ android {
     }
 }
 
+val useLocalProjects = project.rootProject.extra["useLocalProjects"] as Boolean
+
 dependencies {
-    api("com.openmobilehub.android.auth:core:2.0.0-beta")
+    if(useLocalProjects) {
+        api(project(":packages:core"))
+    } else {
+        api("com.openmobilehub.android.auth:core:2.0.0-beta")
+    }
 
     // KTX
     implementation(Libs.coreKtx)


### PR DESCRIPTION
This change allows for:
- using Maven local when passing a Gradle parameter or setting in `local.properties` of the root project `useMavenLocal` to `true` (as described in the updated `CONTRIBUTING.md`)
- using local projects as dependencies for building sample app bundles when a Gradle parameter or setting in `local.properties` of the root project `useMavenLocal` to `true`