### PR TITLE
fix: fixed missing permissions in publish docs workflow

### DIFF
--- a/.github/workflows/build_and_publish_docs.yml
+++ b/.github/workflows/build_and_publish_docs.yml
@@ -4,6 +4,12 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# GITHUB_TOKEN needs to be granted the permissions required to make a Pages deployment
+permissions:
+  contents: read
+  pages: write # to deploy to Pages
+  id-token: write # to verify the deployment originates from an appropriate source
+
 jobs:
   build-documentation:
     name: Build documentation
@@ -71,7 +77,7 @@ jobs:
         run: cp -r docs/markdown/_site built_docs/advanced-docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: built_docs
 
@@ -87,4 +93,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Fixes issue https://github.com/openmobilehub/android-omh-auth/issues/72 

## Checklist:
- [X] Documentation is up to date to reflect these changes
- [X] Created Unit tests
