### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ provider implementations.
 
 | GMS Device                                                                           | Non GMS Device                                                                           |
 |--------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-| ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_gms.gif) | ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_non_gms.gif) |
+| !<img src="https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_gms.gif?raw=true" width=250 /> | <img src="https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_non_gms.gif?raw=true" width=250 /> |
 
 </div>
 
@@ -37,7 +37,7 @@ provider implementations.
 
 | Facebook login                                                                            | Microsoft login                                                                     | Dropbox login                                                                            |
 |-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-| ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_facebook.gif) | ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_ms.gif) | ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_dropbox.gif) |
+| ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_facebook.gif?raw=true) | ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_ms.gif?raw=true) | ![](https://github.com/openmobilehub/android-omh-auth/blob/main/assets/auth_dropbox.gif?raw=true) |
 <div align="center">
 
 </div>


### PR DESCRIPTION
Fix documentation gifs links
Fixes #68

## Summary

Looks like for webpage docs we need to pass `?raw=true` at the end of gif-s url. 

Now both Readme and Web should work ✌️ 

