### PR TITLE
fix: add keep ApiService proguard rule

### DIFF
--- a/packages/plugin-microsoft/consumer-rules.pro
+++ b/packages/plugin-microsoft/consumer-rules.pro
@@ -2,3 +2,4 @@
 -dontwarn edu.umd.cs.**
 -dontwarn org.bouncycastle.**
 -dontwarn com.microsoft.device.display.DisplayMask
+-keep class com.openmobilehub.android.auth.plugin.microsoft.ApiService { *; }


### PR DESCRIPTION
## Summary
This missing consumer rule could cause a crash on client end.

## Demo
n/a

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: n/a
