### PR TITLE
Allow initialize MicrosoftApplication instance using InputStream instead of resource ID

### DIFF
--- a/packages/plugin-microsoft/src/main/java/com/openmobilehub/android/auth/plugin/microsoft/MicrosoftApplication.kt
+++ b/packages/plugin-microsoft/src/main/java/com/openmobilehub/android/auth/plugin/microsoft/MicrosoftApplication.kt
@@ -3,9 +3,12 @@ package com.openmobilehub.android.auth.plugin.microsoft
 import android.content.Context
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication
 import com.microsoft.identity.client.PublicClientApplication
+import com.microsoft.identity.client.PublicClientApplicationConfiguration
 import com.openmobilehub.android.auth.core.models.OmhAuthException
+import com.openmobilehub.android.auth.plugin.microsoft.utils.PublicClientApplicationConfigurationLoader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.InputStream
 
 class MicrosoftApplication {
     private var application: ISingleAccountPublicClientApplication? = null
@@ -16,6 +19,21 @@ class MicrosoftApplication {
         }
 
         return application!!
+    }
+
+    suspend fun initialize(context: Context, source: InputStream) {
+        withContext(Dispatchers.IO) {
+            val config = PublicClientApplicationConfigurationLoader
+                .createSingleAccountPublicClientApplication(context, source)
+            val createSingleAccountPublicClientApplication = PublicClientApplication::class.java
+                .getDeclaredMethod(
+                    "createSingleAccountPublicClientApplication",
+                    PublicClientApplicationConfiguration::class.java
+                )
+            createSingleAccountPublicClientApplication.isAccessible = true
+            application = createSingleAccountPublicClientApplication
+                .invoke(null, config) as ISingleAccountPublicClientApplication
+        }
     }
 
     suspend fun initialize(context: Context, configFileResourceId: Int) {

--- a/packages/plugin-microsoft/src/main/java/com/openmobilehub/android/auth/plugin/microsoft/utils/PublicClientApplicationConfigurationLoader.kt
+++ b/packages/plugin-microsoft/src/main/java/com/openmobilehub/android/auth/plugin/microsoft/utils/PublicClientApplicationConfigurationLoader.kt
@@ -1,0 +1,61 @@
+package com.openmobilehub.android.auth.plugin.microsoft.utils
+
+import android.content.Context
+import com.google.gson.Gson
+import com.microsoft.identity.client.PublicClientApplicationConfiguration
+import com.microsoft.identity.client.PublicClientApplicationConfigurationFactory
+import java.io.InputStream
+
+/**
+ * Singleton to load configuration for initializing MS Graph SDK.
+ *
+ * Originally MS Graph SDK only allows load configuration by specifying a raw JSON resource bundled
+ * into the app. However this loses flexibility that configuration JSON that may not be bundled
+ * but available from any other InputStreams, hence this object.
+ *
+ * Relies heavily on reflection to invoke private static methods inside
+ * [PublicClientApplicationConfigurationFactory] so may break in the future, should MS Graph SDK
+ * changes its API or the feature request at
+ * https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/2201 is
+ * eventually solved.
+ */
+object PublicClientApplicationConfigurationLoader {
+
+    private val initializeConfigurationInternal = PublicClientApplicationConfigurationFactory::class.java
+        .getDeclaredMethod(
+            "initializeConfigurationInternal",
+            Context::class.java,
+            PublicClientApplicationConfiguration::class.java
+        )
+
+    private val getGsonForLoadingConfiguration = PublicClientApplicationConfigurationFactory::class.java
+        .getDeclaredMethod("getGsonForLoadingConfiguration")
+
+    /**
+     * Public facing method, load [PublicClientApplicationConfiguration] using given [InputStream].
+     *
+     * @param context [Context]
+     * @param config [InputStream]
+     */
+    @JvmStatic
+    fun createSingleAccountPublicClientApplication(
+        context: Context,
+        config: InputStream
+    ): PublicClientApplicationConfiguration {
+        initializeConfigurationInternal.isAccessible = true
+        return initializeConfigurationInternal.invoke(
+            null,
+            context,
+            loadPublicClientApplicationConfigurationFrom(config)
+        ) as PublicClientApplicationConfiguration
+    }
+
+    @JvmStatic
+    private fun loadPublicClientApplicationConfigurationFrom(
+        source: InputStream
+    ): PublicClientApplicationConfiguration {
+        getGsonForLoadingConfiguration.isAccessible = true
+        val gson = getGsonForLoadingConfiguration.invoke(null) as Gson
+        return gson.fromJson(source.reader(), PublicClientApplicationConfiguration::class.java)
+    }
+}

--- a/packages/plugin-microsoft/src/test/java/com/openmobilehub/android/auth/plugin/microsoft/MicrosoftAuthClientTest.kt
+++ b/packages/plugin-microsoft/src/test/java/com/openmobilehub/android/auth/plugin/microsoft/MicrosoftAuthClientTest.kt
@@ -65,7 +65,7 @@ class MicrosoftAuthClientTest {
         every {
             appMock.getApplication()
         } throws OmhAuthException.NotInitializedException()
-        coEvery { appMock.initialize(any(), any()) } returns mockk()
+        coEvery { appMock.initialize(any(), any<Int>()) } returns mockk()
 
         val client = MicrosoftAuthClient(
             configFileResourceId = configFileResourceId,
@@ -75,7 +75,7 @@ class MicrosoftAuthClientTest {
 
         client.initialize().addOnSuccess(callbackMock).execute()
 
-        coVerify { appMock.initialize(any(), any()) }
+        coVerify { appMock.initialize(any(), any<Int>()) }
         coVerify { callbackMock.onSuccess(Unit) }
     }
 


### PR DESCRIPTION
## Summary

Workaround to enable us to load MS Graph SDK configuration JSON via resources available elsewhere, be it other app bundle, or network.

Hacky, and depends on internal API, before https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/2201 gets fixed.

## Checklist:
- [ ] Documentation is up to date to reflect these changes
- [ ] Created Unit tests